### PR TITLE
[BUG] fixes keyboard shortcuts context

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,67 +31,80 @@
 			{
 				"command": "extension.selectSingleQuote",
 				"key": "ctrl+k '",
-        "mac": "cmd+k '"
+        		"mac": "cmd+k '",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectDoubleQuote",
 				"key": "ctrl+k shift+'",
-        "mac": "cmd+k shift+'"
+        		"mac": "cmd+k shift+'",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectEitherQuote",
 				"key": "ctrl+k ;",
-        "mac": "cmd+k ;"
+        		"mac": "cmd+k ;",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.switchQuotes",
 				"key": "ctrl+k shift+;",
-        "mac": "cmd+k shift+;"
+        		"mac": "cmd+k shift+;",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectParenthesis",
 				"key": "ctrl+k shift+9",
-        "mac": "cmd+k shift+9"
+        		"mac": "cmd+k shift+9",
+				"when": "editorFocus"
 			},
-      {
+      		{
 				"command": "extension.selectBackTick",
 				"key": "ctrl+k `",
-        "mac": "cmd+k `"
+        		"mac": "cmd+k `",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectSquareBrackets",
 				"key": "ctrl+k [",
-        "mac": "cmd+k ["
+        		"mac": "cmd+k [",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectCurlyBrackets",
 				"key": "ctrl+k shift+[",
-        "mac": "cmd+k shift+["
+        		"mac": "cmd+k shift+[",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectParenthesisOuter",
 				"key": "ctrl+k shift+0",
-        "mac": "cmd+k shift+0"
+        		"mac": "cmd+k shift+0",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectSquareBracketsOuter",
 				"key": "ctrl+k ]",
-        "mac": "cmd+k ]"
+        		"mac": "cmd+k ]",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectCurlyBracketsOuter",
 				"key": "ctrl+k shift+]",
-        "mac": "cmd+k shift+]"
+        		"mac": "cmd+k shift+]",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectAngleBrackets",
 				"key": "ctrl+k shift+,",
-        "mac": "cmd+k shift+,"
+        		"mac": "cmd+k shift+,",
+				"when": "editorFocus"
 			},
 			{
 				"command": "extension.selectInTag",
 				"key": "ctrl+k shift+.",
-        "mac": "cmd+k shift+."
+        		"mac": "cmd+k shift+.",
+				"when": "editorFocus"
 			}
 		]
 	},


### PR DESCRIPTION
This is adding the `when` option to the keyboard shortcuts, so that they trigger only within the editor, and not for example in the terminal.

Before you couldn't clear a terminal window with `CMD+K` anymore as it was triggering this extension's shortcuts. Now the shortcuts are limited to run only when an editor has the focus.